### PR TITLE
A few changes to make the project usable with Clang on Linux.

### DIFF
--- a/include/ei/elementarytypes.hpp
+++ b/include/ei/elementarytypes.hpp
@@ -46,7 +46,7 @@ namespace ei { namespace details {
     class NonScalarType    {};
 
     template<typename T, typename F>
-    T hard_cast(F _from)
+    constexpr T hard_cast(F _from)
     {
         static_assert(sizeof(T) == sizeof(F), "Cannot cast types of different sizes");
         return *reinterpret_cast<T*>(&_from);
@@ -64,8 +64,8 @@ namespace ei {
     // The cmath header has an ugly macro with name INFINITY -> name conflict
 #pragma warning(push)
 #pragma warning(disable:4056) // overflow in fp constant arithmetic
-    const float INF = 1e30f * 1e30f;
-    const double INF_D = 1e300 * 1e300;
+    constexpr float INF{std::numeric_limits<float>::infinity()};
+    constexpr double INF_D{std::numeric_limits<double>::infinity()};
 #pragma warning(pop)
     // Unicode names for the above constants
 #ifdef EI_USE_UNICODE_NAMES
@@ -165,7 +165,7 @@ namespace ei {
 
     // ********************************************************************* //
     /// \brief Get the sign of a value.
-    /// \details There is a faster version sgn(), if you don't need to 
+    /// \details There is a faster version sgn(), if you don't need to
     ///    know about zero.
     /// \returns -1 (_x < 0), 0 (_x == 0) or 1 (_x > 0)
     template<typename T>

--- a/include/ei/quaternion.hpp
+++ b/include/ei/quaternion.hpp
@@ -44,9 +44,7 @@ namespace ei {
         ///     rotationZ(_z) * rotationY(_y) * rotationX(_x)
         constexpr TQuaternion( T _x, T _y, T _z ) noexcept // TESTED
         {
-            double halfAngle;
-
-            halfAngle = _x * 0.5;
+            double halfAngle = _x * 0.5;
             double sinX = sin(halfAngle);
             double cosX = cos(halfAngle);
 
@@ -147,7 +145,7 @@ namespace ei {
             eiAssert(approx(len(_to),1.0f), "Input (_to) must be normalized direction vector.");
             // half angle trick from http://physicsforgames.blogspot.de/2010/03/quaternion-tricks.html
             Vec<T,3> half = normalize(_from + _to);
-            // Opposite vectors or one vector 0.0 -> 180° rotation
+            // Opposite vectors or one vector 0.0 -> 180Â° rotation
             if(std::isnan(half.x))
             {
                 if(approx(ei::abs(_from.y), static_cast<T>(1)))

--- a/include/ei/vector.hpp
+++ b/include/ei/vector.hpp
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 
 #include <type_traits>
 #include <utility>
@@ -52,7 +52,7 @@ namespace ei {
 #       define ENABLE_IF(condition) typename = std::enable_if_t< (condition) >
 
         /// \brief Construction without initialization. The values are undefined!
-        Matrix() noexcept {}
+        constexpr Matrix() noexcept {}
 
         /// \brief Convert a matrix/vector with a different elementary type.
         template<typename T1>
@@ -1163,6 +1163,18 @@ namespace ei {
     // ********************************************************************* //
 
     // ********************************************************************* //
+    /// \brief Generate the N x N diagonal matrix.
+    /// \param [in] _v0 A vector with the diagonal entries.
+    template<typename T, unsigned N>
+    constexpr inline Matrix<T,N,N> diag( const Vec<T,N>& _v0 ) noexcept // TESTED
+    {
+        Matrix<T,N,N> result(T(0));
+        for(uint n = 0; n < N; ++n)
+            result[n * N + n] = _v0[n];
+        return result;
+    }
+
+    // ********************************************************************* //
     /// \brief Generate the N x N identity matrix.
     template<typename T, unsigned N>
     constexpr inline Matrix<T,N,N> identity() noexcept // TESTED
@@ -1176,18 +1188,6 @@ namespace ei {
     constexpr inline Mat3x3 identity3x3() noexcept    { return identity<float,3>(); } // TESTED
     /// \brief Alias for identity<float,4>().
     constexpr inline Mat4x4 identity4x4() noexcept    { return identity<float,4>(); } // TESTED
-
-    // ********************************************************************* //
-    /// \brief Generate the N x N diagonal matrix.
-    /// \param [in] _v0 A vector with the diagonal entries.
-    template<typename T, unsigned N>
-    constexpr inline Matrix<T,N,N> diag( const Vec<T,N>& _v0 ) noexcept // TESTED
-    {
-        Matrix<T,N,N> result(T(0));
-        for(uint n = 0; n < N; ++n)
-            result[n * N + n] = _v0[n];
-        return result;
-    }
 
     // ********************************************************************* //
     /// \brief Convert a vector from Cartesian coordinates in spherical


### PR DESCRIPTION
* `hard_cast`, `INF`, `INF_D` and `Matrix::Matrix()` are now `constexpr`.
* `Matrix::diag` has been moved before `Matrix::identity`, where it is used.