### PR TITLE
Added CMake support and fixed some compilation errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,73 @@
+cmake_minimum_required(VERSION 3.0.2 FATAL_ERROR)
+cmake_policy(VERSION 3.0.2)
+
+project(epsilon VERSION 0.1 LANGUAGES CXX)
+
+# Control whether to add unit test target or not
+option(EPSILON_ENABLE_UNIT_TESTS "Create unit test target" ON)
+
+# Basic library target (header only)
+add_library(epsilon INTERFACE)
+target_include_directories(epsilon INTERFACE
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+)
+
+# Create version compatibility
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+    "${PROJECT_BINARY_DIR}/epsilonConfigVersion.cmake"
+    VERSION 0.1
+    COMPATIBILITY AnyNewerVersion
+)
+
+# Install the library to the chosen CMAKE_INSTALL_PREFIX with normal folder structure
+install(TARGETS epsilon
+    EXPORT epsilonTargets
+    LIBRARY DESTINATION lib COMPONENT Runtime
+    ARCHIVE DESTINATION lib COMPONENT Development
+    RUNTIME DESTINATION bin COMPONENT Runtime
+    PUBLIC_HEADER DESTINATION include COMPONENT Development
+    BUNDLE DESTINATION bin COMPONENT Runtime
+)
+
+# Create the configuration file to allow find_package(epsilon)
+configure_package_config_file(
+    "${PROJECT_SOURCE_DIR}/cmake/epsilonConfig.cmake.in"
+    "${PROJECT_BINARY_DIR}/epsilonConfig.cmake"
+    INSTALL_DESTINATION lib/cmake/mylib
+)
+install(EXPORT epsilonTargets DESTINATION lib/cmake/epsilon)
+install(FILES "${PROJECT_BINARY_DIR}/epsilonConfigVersion.cmake"
+              "${PROJECT_BINARY_DIR}/epsilonConfig.cmake"
+        DESTINATION lib/cmake/epsilon)
+# Copy over the header files
+install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/ DESTINATION include)
+
+if(EPSILON_ENABLE_UNIT_TESTS)
+	message(STATUS "Building unit tests")
+	# Unit test (does not get installed of course)
+	add_executable(epsilon_unittest
+		${PROJECT_SOURCE_DIR}/unittest/conversions.cpp
+		${PROJECT_SOURCE_DIR}/unittest/eiconfig.hpp
+		${PROJECT_SOURCE_DIR}/unittest/elementarytypes.cpp
+		${PROJECT_SOURCE_DIR}/unittest/intersection2d.cpp
+		${PROJECT_SOURCE_DIR}/unittest/intersection3d.cpp
+		${PROJECT_SOURCE_DIR}/unittest/main.cpp
+		${PROJECT_SOURCE_DIR}/unittest/matrix.cpp
+		${PROJECT_SOURCE_DIR}/unittest/performance3d.hpp
+		${PROJECT_SOURCE_DIR}/unittest/prime.cpp
+		${PROJECT_SOURCE_DIR}/unittest/quaternion.cpp
+		${PROJECT_SOURCE_DIR}/unittest/stdextensions.cpp
+		${PROJECT_SOURCE_DIR}/unittest/types2d.cpp
+		${PROJECT_SOURCE_DIR}/unittest/types3d.cpp
+		${PROJECT_SOURCE_DIR}/unittest/unittest.cpp
+		${PROJECT_SOURCE_DIR}/unittest/unittest.hpp
+	)
+	# The unit test makes some assumptions about include paths (not specifying 'ei/')
+	target_include_directories(epsilon_unittest PRIVATE
+		${PROJECT_SOURCE_DIR}/unittest
+		${PROJECT_SOURCE_DIR}/include/ei
+	)
+	target_link_libraries(epsilon_unittest epsilon)
+endif()

--- a/cmake/epsilonConfig.cmake.in
+++ b/cmake/epsilonConfig.cmake.in
@@ -1,0 +1,4 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/epsilonTargets.cmake")
+check_required_components("@PROJECT_NAME@")

--- a/include/ei/elementarytypes.hpp
+++ b/include/ei/elementarytypes.hpp
@@ -186,11 +186,11 @@ namespace ei {
     {
         return _x < static_cast<T>(0) ? static_cast<T>(-1) : static_cast<T>(1);
     }
-    EIAPI constexpr inline float sgn(float _x) noexcept // TESTED
+    EIAPI inline float sgn(float _x) noexcept // TESTED
     {
         return details::hard_cast<uint32>(_x) & 0x80000000 ? -1.0f : 1.0f;
     }
-    EIAPI constexpr inline double sgn(double _x) noexcept // TESTED
+    EIAPI inline double sgn(double _x) noexcept // TESTED
     {
         return details::hard_cast<uint64>(_x) & 0x8000000000000000ull ? -1.0 : 1.0;
     }
@@ -203,11 +203,11 @@ namespace ei {
     {
         return _x < static_cast<T>(0) ? 0 : 1;
     }
-    EIAPI constexpr inline int heaviside(float _x) noexcept // TESTED
+    EIAPI inline int heaviside(float _x) noexcept // TESTED
     {
         return details::hard_cast<uint32>(_x) & 0x80000000 ? 0 : 1;
     }
-    EIAPI constexpr inline int heaviside(double _x) noexcept // TESTED
+    EIAPI inline int heaviside(double _x) noexcept // TESTED
     {
         return details::hard_cast<uint64>(_x) & 0x8000000000000000ull ? 0 : 1;
     }
@@ -433,7 +433,7 @@ namespace ei {
     ///    denormalized range. Thereby the successor of -0 and 0 are both the
     ///    same smallest positive float. Further -INF is transformed into
     ///    -FLOAT_MAX and +INF remains +INF.
-    EIAPI constexpr inline float successor(float _number) noexcept // TESTED
+    EIAPI inline float successor(float _number) noexcept // TESTED
     {
         // Handling NaN
         if(_number != _number) return _number;
@@ -449,7 +449,7 @@ namespace ei {
         else return details::hard_cast<float>( mantissa + 1 );
     }
 
-    EIAPI constexpr inline double successor(double _number) noexcept
+    EIAPI inline double successor(double _number) noexcept
     {
         // Handling NaN
         if(_number != _number) return _number;
@@ -470,7 +470,7 @@ namespace ei {
     ///    denormalized range. Thereby the predecessor of -0 and 0 are both the
     ///    same smallest negative float. Further -INF remains -INF and + INF
     ///    is transformed into FLOAT_MAX.
-    EIAPI constexpr inline float predecessor(float _number) noexcept // TESTED
+    EIAPI inline float predecessor(float _number) noexcept // TESTED
     {
         // Handling NaN
         if(_number != _number) return _number;
@@ -486,7 +486,7 @@ namespace ei {
         else return details::hard_cast<float>( mantissa - 1 );
     }
 
-    EIAPI constexpr inline double predecessor(double _number) noexcept
+    EIAPI inline double predecessor(double _number) noexcept
     {
         // Handling NaN
         if(_number != _number) return _number;
@@ -540,20 +540,20 @@ namespace ei {
     {
     private:
         // Template helpers to get some compiletime contants
-        template<typename T1> struct MinInterval {
+        template<typename T1, class Dummy = void> struct MinInterval {
             static constexpr float value = -1.0f;
         };
-        template<> struct MinInterval<typename details::Int<sizeof(T)>::utype> {
+        template<class Dummy> struct MinInterval<typename details::Int<sizeof(T)>::utype, Dummy> {
             static constexpr float value = 0.0f;
         };
-        template<typename T1> struct MaxValue {
+        template<typename T1, class Dummy = void> struct MaxValue {
             static constexpr uint64 value = 0xffffffffffffffffull >> (64u - Bits + 1u);
         };
-        template<> struct MaxValue<typename details::Int<sizeof(T)>::utype> {
+        template<class Dummy> struct MaxValue<typename details::Int<sizeof(T)>::utype, Dummy> {
             static constexpr uint64 value = 0xffffffffffffffffull >> (64u - Bits);
         };
     public:
-        static_assert(std::is_integral_v<T>, "NormalizedInt can only use integer types as basis type.");
+        static_assert(std::is_integral<T>::value, "NormalizedInt can only use integer types as basis type.");
         static_assert(Bits <= sizeof(T)*8, "Base type as not enough bits.");
         //static constexpr float INTERVAL_MIN = []{ if(std::is_signed_v<T>) return -1.0f; else return 0.0f; }();
         static constexpr float INTERVAL_MIN = MinInterval<T>::value;
@@ -565,7 +565,7 @@ namespace ei {
 
         NormalizedInt() = default;
 
-        template<typename T1, typename = std::enable_if_t<std::is_integral_v<T> && BITS <= sizeof(T1)*8>>
+        template<typename T1, typename = std::enable_if_t<std::is_integral<T>::value && BITS <= sizeof(T1)*8>>
         EIAPI constexpr explicit NormalizedInt(T1 v) noexcept : value(v & MASK)
         {
             // Signed types in 2-complement must have all significant bits set.
@@ -596,7 +596,7 @@ namespace ei {
             return value / double(MAX_POSITIVE_VALUE);
         }
 
-        template<typename T1, typename = std::enable_if_t<std::is_integral_v<T> && BITS <= sizeof(T1)*8>>
+        template<typename T1, typename = std::enable_if_t<std::is_integral<T>::value && BITS <= sizeof(T1)*8>>
         EIAPI constexpr explicit operator T1 () const noexcept { return T1(value); }
     private:
         T value;

--- a/include/ei/stdextensions.hpp
+++ b/include/ei/stdextensions.hpp
@@ -11,7 +11,7 @@ namespace std {
     template <class T> struct equal_to;
 
     /// \brief Custom hash function for vectors.
-    template <typename T, uint M, uint N>
+    template <typename T, ei::uint M, ei::uint N>
     struct hash<ei::Matrix<T, M, N>>
     {
         using argument_type = ei::Matrix<T, M, N>;
@@ -100,7 +100,7 @@ namespace std {
     ///     |m10 m11|
     ///     The printer does not add line breaks at the end. Only the matrix version
     ///     adds line breaks between rows.
-    template <typename T, uint N> // Row vector
+    template <typename T, ei::uint N> // Row vector
     std::ostream& operator << (std::ostream& _os, const ei::Matrix<T, 1, N>& _mat)  // TESTED
     {
         _os << '(';
@@ -111,27 +111,27 @@ namespace std {
         return _os;
     }
 
-    template <typename T, uint M> // Column vector
+    template <typename T, ei::uint M> // Column vector
     std::ostream& operator << (std::ostream& _os, const ei::Matrix<T, M, 1>& _mat)  // TESTED
     {
         _os << '(';
-        for(uint i = 0; i < M-1; ++i)
+        for(ei::uint i = 0; i < M-1; ++i)
             _os << _mat[i] << ", ";
         _os << _mat[M-1] << ")";
 
         return _os;
     }
 
-    template <typename T, uint M, uint N> // Matrix
+    template <typename T, ei::uint M, ei::uint N> // Matrix
     std::ostream& operator << (std::ostream& _os, const ei::Matrix<T, M, N>& _mat)  // TESTED
     {
         // Set to scientific to align columns
         //auto flags = _os.flags();
         //  _os << std::scientific;
-        for(uint j = 0; j < M; ++j)
+        for(ei::uint j = 0; j < M; ++j)
         {
             _os << '|';
-            for(uint i = 0; i < N-1; ++i)
+            for(ei::uint i = 0; i < N-1; ++i)
                 _os << std::setw(11) << _mat[i + N * j] << ' ';
             _os << std::setw(11) << _mat[N-1 + N * j] << '|';
             if(j < M-1)

--- a/include/ei/vector.hpp
+++ b/include/ei/vector.hpp
@@ -39,8 +39,8 @@ namespace ei {
         // construct inherits rules as [int + float -> float] from the
         // elementary types.
 #       define RESULT_TYPE(op) std::enable_if_t<                   \
-            !std::is_base_of_v<details::NonScalarType, T1> &&      \
-            !std::is_base_of_v<details::NonScalarType, T>,         \
+            !std::is_base_of<details::NonScalarType, T1>::value &&      \
+            !std::is_base_of<details::NonScalarType, T>::value,         \
             decltype(std::declval<T>() op std::declval<T1>())      \
         >
 
@@ -52,7 +52,7 @@ namespace ei {
 #       define ENABLE_IF(condition) typename = std::enable_if_t< (condition) >
 
         /// \brief Construction without initialization. The values are undefined!
-        EIAPI Matrix() noexcept {}
+        EIAPI constexpr Matrix() noexcept {}
 
         /// \brief Convert a matrix/vector with a different elementary type.
         template<typename T1>
@@ -63,7 +63,7 @@ namespace ei {
         }
 
         /// \brief Forward to base constructors
-        template<typename T1, ENABLE_IF((!std::is_base_of_v<details::NonScalarType, T1>))>
+        template<typename T1, ENABLE_IF((!std::is_base_of<details::NonScalarType, T1>::value))>
         EIAPI constexpr explicit Matrix(T1 _a0) noexcept :
             details::Components<T,M,N>(_a0)
         {}
@@ -240,11 +240,11 @@ namespace ei {
             EI_CODE_GEN_MAT_MAT_OP(-)
 
         /// \brief Unary minus on all components.
-        template<typename T1 = T, ENABLE_IF(std::is_signed_v<T1>)>
+        template<typename T1 = T, ENABLE_IF(std::is_signed<T1>::value)>
         EIAPI constexpr Matrix<T, M, N> operator - () const noexcept // TESTED
             EI_CODE_GEN_MAT_UNARY_OP(-)
         /// \brief Component wise binary not.
-        template<typename T1 = T, ENABLE_IF(std::is_integral_v<T1>)>
+        template<typename T1 = T, ENABLE_IF(std::is_integral<T1>::value)>
         EIAPI constexpr Matrix<T, M, N> operator ~ () const noexcept // TESTED
             EI_CODE_GEN_MAT_UNARY_OP(~)
 
@@ -1437,7 +1437,7 @@ namespace ei {
                      -_vector.y, _vector.x);
     }
 
-    EIAPI constexpr inline Mat3x3 basis( const Vec3& _vector ) noexcept // TESTED
+    EIAPI inline Mat3x3 basis( const Vec3& _vector ) noexcept // TESTED
     {
         eiAssert(approx(len(_vector), 1.0f), "Expected normalized direction vector!");
         Vec3 y;

--- a/unittest/performance3d.hpp
+++ b/unittest/performance3d.hpp
@@ -170,6 +170,7 @@ template<> inline const char* name<ei::DOP>()           { return "         DOP";
 /// by the following method.
 inline float getTimePer1MElements()
 {
+	using namespace eitypes;
     static float s_timePer1MElements;
     if(s_timePer1MElements == 0.0f) // Not determined yet?
     {


### PR DESCRIPTION
The library can now be installed via CMake or included as a subdirectory/submodule. The compilation errors were due to missing namespace qualifiers and only affect the unit test.